### PR TITLE
Change Trello authorization link to never expire

### DIFF
--- a/options/index.html
+++ b/options/index.html
@@ -17,7 +17,7 @@
     </style>
   </head>
   <body>
-    <a href="https://trello.com/1/authorize?expiration=30days&scope=read,write&response_type=token&name=Trektor&key=2379d540412e417f6f0696c1397f38a6" target="_blank">
+    <a href="https://trello.com/1/authorize?expiration=never&scope=read,write&response_type=token&name=Trektor&key=2379d540412e417f6f0696c1397f38a6" target="_blank">
       Trello Token
     </a>
 


### PR DESCRIPTION
Einfache Lösung, als Alternative zum Vorschlag, dass Trektor sich alle 30 Tage selbst ein neues Token holt.