### PR TITLE
Use more unique id for task names

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -49,7 +49,7 @@ class BackgroundScript {
     let taskName = card.name.match(/(?<=#)[A-Za-z0-9_-]+/)?.[0];
 
     if (taskName === undefined) {
-      taskName = `${taskPrefix}_${card.idShort}`;
+      taskName = `${taskPrefix}_${card.shortLink}`;
 
       await BackgroundScript.trektor.trelloGateway.updateCard(card.id, {
         name: `${card.name} #${taskName}`,


### PR DESCRIPTION
Dieser PR wechselt von der `shortId` zum `shortLink` für die Generierung der Task Namen. Der `shortLink` ist ein 8 Zeichen langer String (zB. IhIigNVq), der in der `shortUrl` (zB. https://trello.com/c/IhIigNVq) enthalten ist und auch über mehrere Boards hinweg unique sein sollte.