### PR TITLE
Improve options page

### DIFF
--- a/options/index.html
+++ b/options/index.html
@@ -2,34 +2,25 @@
 <html lang="en">
   <head>
     <link rel="icon" href="icons/64.png">
+    <link rel="stylesheet" href="style.css">
     <title>Trektor settings</title>
     <meta charset="UTF-8">
-    <style>
-      a {
-        display: block;
-        margin-bottom: 10px;
-      }
-      input {
-        width: 100%;
-        box-sizing: border-box;
-        margin-bottom: 10px;
-      }
-    </style>
   </head>
   <body>
+    <h2>Willkommen bei Trektor!</h2>
+    <div class="notification" id="permissions-granted">✔ Alle Berechtigungen vorhanden</div>
+    <div class="notification" id="permissions-not-granted">✘ Berechtigung fehlt! <button id="request">Anfordern</button></div>
+
     <a href="https://trello.com/1/authorize?expiration=30days&scope=read,write&response_type=token&name=Trektor&key=2379d540412e417f6f0696c1397f38a6" target="_blank">
       Trello Token
     </a>
-
     <input type="text" name="trello" />
 
     <a href="https://track.toggl.com/profile" target="_blank">
       Toggl Token
     </a>
-
     <input type="text" name="toggl" />
 
-    <script src="../vendor/browser-polyfill.js"></script>
     <script src="./script.js"></script>
   </body>
 </html>

--- a/options/script.js
+++ b/options/script.js
@@ -1,3 +1,15 @@
+if (typeof browser == "undefined") {
+  globalThis.browser = chrome
+}
+
+const permissions = {
+  origins: [
+    "https://api.trello.com/*",
+    "https://api.track.toggl.com/*",
+    "https://trello.com/*"
+  ]
+}
+
 document.querySelectorAll("input").forEach((field) => {
   field.addEventListener("input", (e) => {
     browser.storage.local.set({ [e.target.name]: e.target.value });
@@ -7,3 +19,24 @@ document.querySelectorAll("input").forEach((field) => {
     field.value = (value === undefined) ? "" : value;
   });
 });
+
+check_permissions()
+
+document.getElementById("request").addEventListener("click", () => { requestPermissions() })
+
+function requestPermissions() {
+  console.log("hallo")
+  browser.permissions.request(permissions, () => { check_permissions() })
+}
+
+function check_permissions() {
+  browser.permissions.contains(permissions, (contains) => {
+    if (contains) {
+      document.getElementById("permissions-granted").style.display = "block";
+      document.getElementById("permissions-not-granted").style.display = "none";
+    } else {
+      document.getElementById("permissions-granted").style.display = "none";
+      document.getElementById("permissions-not-granted").style.display = "block";
+    }
+  })
+}

--- a/options/style.css
+++ b/options/style.css
@@ -1,0 +1,30 @@
+a {
+  display: block;
+  color: blue;
+  margin: 10px;
+}
+input {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 10px;
+}
+body {
+  font-family: sans-serif;
+  width: 90%;
+  max-width: 500px;
+  margin: 1.5rem auto;
+}
+
+#permissions-granted {
+  background-color: rgba(0, 255, 0, 0.5);
+  border: 2px green solid;
+}
+#permissions-not-granted {
+  background-color: rgba(255, 20, 0, 0.5);
+  border: 2px red solid;
+}
+.notification {
+  text-align: center;
+  padding: 10px;
+  border-radius: 10px;
+}


### PR DESCRIPTION
Dieser PR fügt eine Möglichkeit hinzu, von der options page aus Trektor die nötigen Berechtigungen zu geben, da Firefox unsere host_permissions als optional behandelt und sie also möglicherweise noch nicht gegeben sind.  Außerdem wird die options page automatisch geöffnet, wenn man Trektor installiert.
Dadurch soll die initiale Einrichtung etwas komfortabler werden.